### PR TITLE
Fix handling of CLI options

### DIFF
--- a/bin/loopback-cli.js
+++ b/bin/loopback-cli.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const assert = require('assert');
+const camelCaseKeys = require('camelcase-keys');
 const debug = require('debug')('loopback:cli');
 const nopt = require('nopt');
 const path = require('path');
@@ -67,7 +68,10 @@ const originalCommand = args.shift();
 const command = 'loopback:' + (originalCommand || 'app');
 args.unshift(command);
 debug('invoking generator', args);
-delete opts.argv;
+
+// `yo` is adding flags converted to CamelCase
+const options = camelCaseKeys(opts, {exclude: ['--', /^\w$/, 'argv']});
+Object.assign(options, opts);
 
 // Handle unknown command (generator)
 // This code overrides the error reported by yeoman:
@@ -87,7 +91,5 @@ try {
   process.exit(1);
 }
 
-// TODO(bajtos) implement support for "opts.help"
-
-debug('env.run %j %j', args, opts);
-env.run(args, opts);
+debug('env.run %j %j', args, options);
+env.run(args, options);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     }
   },
   "dependencies": {
+    "camelcase-keys": "^4.0.0",
     "debug": "^2.3.3",
     "generator-loopback": "^2.2.0",
     "nopt": "^4.0.1"

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -91,6 +91,15 @@ describe('smoke tests - lb', () => {
       });
   });
 
+  it('honours "lb app" flag --skip-next-steps', () => {
+    const prompts = {appName: 'test-app', appDir: '.'};
+    return invoke(['app', '--skip-install', '--skip-next-steps'], prompts)
+      .then(result => {
+        expect(result.stdout).to.not.match(/next steps/i);
+        expect(result.stderr).to.not.match(/next steps/i);
+      });
+  });
+
   it('creates a model via "lb model"', () => {
     const prompts = {
       modelName: 'test-model',


### PR DESCRIPTION
### Description

Fix the code building `options` from CLI args to add camelCased variant, in order to match the behaviour of `yo`.

This fixes the bug where "lb --skip-next-steps" was not recognized.

#### Related issues

- https://github.com/strongloop-internal/scrum-loopback/issues/1411

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
