### PR TITLE
Include workspace version in --version log

### DIFF
--- a/bin/loopback-cli.js
+++ b/bin/loopback-cli.js
@@ -25,7 +25,9 @@ const opts = nopt({
 if (opts.version) {
   const ourVersion = require('../package.json').version;
   const generatorVersion = require('generator-loopback/package.json').version;
-  console.log('%s (generator-loopback@%s)', ourVersion, generatorVersion);
+  const workspaceVersion = require('generator-loopback').workspaceVersion;
+  console.log('%s (generator-loopback@%s loopback-workspace@%s)',
+    ourVersion, generatorVersion, workspaceVersion);
   return;
 }
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -13,6 +13,7 @@ const sandbox = require('./helpers/sandbox');
 
 const OUR_VERSION = require('../package.json').version;
 const GENERATOR_VERSION = require('generator-loopback/package.json').version;
+const WORKSPACE_VERSION = require('generator-loopback').workspaceVersion;
 
 // These tests invoke `loopback-cli` in a sub-process and perform
 // a very minimal verification of invoked command's results.
@@ -28,7 +29,8 @@ describe('smoke tests - lb', () => {
     return invoke(['--version']).then(result => {
       expect(result.exitCode).to.eql(0);
       expect(result.stdout).to.contain(OUR_VERSION)
-        .and.contain(GENERATOR_VERSION);
+        .and.contain(GENERATOR_VERSION)
+        .and.contain(WORKSPACE_VERSION);
     });
   });
 


### PR DESCRIPTION
### Description

Enhance the output of `lb --version` to include the version of loopback-workspace. This should simplify support for users running into problems.

Example output:

```
$ ./bin/loopback-cli.js -v
2.1.0 (generator-loopback@3.0.0 loopback-workspace@3.36.1)
````

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- The idea to include workspace version was triggered by the discussion in #3144.
- This change depends on https://github.com/strongloop/generator-loopback/pull/275 to be landed and released first.

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
