### PR TITLE
Add `lb:oracle` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "camelcase-keys": "^4.0.0",
     "debug": "^2.6.1",
-    "generator-loopback": "^3.4.0",
+    "generator-loopback": "^3.5.0",
     "nopt": "^4.0.1"
   },
   "devDependencies": {

--- a/test/fixtures/help-lb-oracle.txt
+++ b/test/fixtures/help-lb-oracle.txt
@@ -1,0 +1,20 @@
+Usage:
+  lb oracle [options]
+
+Options:
+  -h,   --help          # Print the generator's options and usage
+        --skip-cache    # Do not remember prompt answers             Default: false
+        --skip-install  # Do not automatically install dependencies  Default: false
+        --connector     # Install loopback-connector-oracle module
+        --driver        # Install oracledb module
+        --verbose       # Print verbose information
+
+Description:
+  Utility to help install LoopBack Oracle connector.
+
+Example:
+
+  lb oracle [--connector] [--driver] [--verbose]
+
+Without options, the command will try to detect the installation of Oracle Instant Client and check if `loopback-connector-oracle` can be loaded.
+

--- a/test/fixtures/help-lb.txt
+++ b/test/fixtures/help-lb.txt
@@ -41,6 +41,7 @@ Available commands:
   lb export-api-def
   lb middleware
   lb model
+  lb oracle
   lb property
   lb relation
   lb remote-method

--- a/test/help.test.js
+++ b/test/help.test.js
@@ -21,6 +21,7 @@ const COMMANDS = [
   'export-api-def',
   'middleware',
   'model',
+  'oracle',
   'property',
   'relation',
   'remote-method',


### PR DESCRIPTION
### Description

The PR adds `lb oracle` command to help install/troubleshoot oracle connector/driver.

#### Related issues

https://github.com/strongloop/generator-loopback/pull/274
https://github.com/strongloop/loopback.io/pull/366

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
