### PR TITLE
Switch from nopts to minimist for args parsing

### DIFF
--- a/bin/loopback-cli.js
+++ b/bin/loopback-cli.js
@@ -9,17 +9,15 @@
 const assert = require('assert');
 const camelCaseKeys = require('camelcase-keys');
 const debug = require('debug')('loopback:cli');
-const nopt = require('nopt');
+const minimist = require('minimist');
 const path = require('path');
 
-const opts = nopt({
-  help: Boolean,
-  version: Boolean,
-  commands: Boolean,
-}, {
-  h: '--help',
-  v: '--version',
-  l: '--commands',
+const opts = minimist(process.argv.slice(2), {
+  alias: {
+    help: 'h',
+    version: 'v',
+    commands: 'l',
+  },
 });
 
 if (opts.version) {
@@ -65,7 +63,7 @@ if (opts.commands) {
   return;
 }
 
-const args = opts.argv.remain;
+const args = opts._;
 const originalCommand = args.shift();
 const command = 'loopback:' + (originalCommand || 'app');
 args.unshift(command);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "camelcase-keys": "^4.0.0",
     "debug": "^2.6.1",
     "generator-loopback": "^3.6.0",
-    "nopt": "^4.0.1"
+    "minimist": "^1.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
It turns out that `yo` CLI uses `minimist` under the hood, even though `yeoman-generator` itself uses `nopts`.

The notable difference is in how an unknown option with a value is handled. Consider the following command:

    lb export-api-def -o ./testApp.yaml

nopts treats "-o" as a boolean flag, leaving "./testApp.yaml" as an unprocessed argument.

minimist recognizes "-o" as a flag with value "./testApp.yaml", which is exactly what we need here.

Fix #27
