### PR TITLE
Support `lb [command | appName]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install -g loopback-cli
 
 ### Getting started
 
- 1. Run `lb` to create a new LoopBack application.
+ 1. Run `lb [appName]` to create a new LoopBack application.
  2. Run `node .` to start the scaffolded server.
 
 ### What's next

--- a/bin/loopback-cli.js
+++ b/bin/loopback-cli.js
@@ -65,31 +65,24 @@ if (opts.commands) {
 
 const args = opts._;
 const originalCommand = args.shift();
-const command = 'loopback:' + (originalCommand || 'app');
-args.unshift(command);
+let command = 'loopback:' + (originalCommand || 'app');
+const supportedCommands = env.getGeneratorsMeta();
+
+if (!(command in supportedCommands)) {
+  command = 'loopback:app';
+  args.unshift(originalCommand);
+  args.unshift(command);
+} else {
+  args.unshift(command);
+}
+
 debug('invoking generator', args);
 
 // `yo` is adding flags converted to CamelCase
 const options = camelCaseKeys(opts, {exclude: ['--', /^\w$/, 'argv']});
 Object.assign(options, opts);
 
-// Handle unknown command (generator)
-// This code overrides the error reported by yeoman:
-//   You don’t seem to have a generator with the name “' + n + '” installed.
-//   But help is on the way:
-//   (etc.)
-try {
-  const generator = env.create(command, {args});
-  if (generator instanceof Error)
-    throw generator;
-} catch (err) {
-  debug('Cannot load generator %s: %s', command, err.stack);
-  console.error(
-    'Unknown command %j\n' +
-      'Run "%s --commands" to print the list of available commands.',
-    originalCommand, process.argv[1]);
-  process.exit(1);
-}
+const generator = env.create(command, {args});
 
 debug('env.run %j %j', args, options);
 env.run(args, options);

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -61,14 +61,6 @@ describe('smoke tests - lb', () => {
     });
   });
 
-  it('reports custom error instead of "generator not installed"', () => {
-    return invoke(['unknown']).then(result => {
-      expect(result.exitCode).to.eql(1);
-      expect(result.stderr).to.contain('Unknown command')
-        .and.not.contain('generator');
-    });
-  });
-
   it('creates a new loopback project via "lb"', () => {
     const prompts = {appName: 'test-app', appDir: '.'};
     return invoke(['--skip-install'], prompts)
@@ -91,6 +83,15 @@ describe('smoke tests - lb', () => {
       .then(result => {
         const pkg = require(sandbox.resolve('package.json'));
         expect(pkg.name, 'package name').to.eql('test-app');
+      });
+  });
+
+  it('accepts a name for the loopback project', () => {
+    const prompts = {appName: 'my-app', appDir: '.'};
+    return invoke(['my-app', '--skip-install'], prompts)
+      .then(result => {
+        const pkg = require(sandbox.resolve('package.json'));
+        expect(pkg.name, 'package name').to.eql('my-app');
       });
   });
 


### PR DESCRIPTION
### Description

`lb my-app` will set the default app and dir name as "my-app".

Regular `lb [command]` not affected.

#### Related issues

https://github.com/strongloop-internal/scrum-asteroid/issues/256

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
