### PR TITLE
Update help-lb message

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "camelcase-keys": "^4.0.0",
     "debug": "^2.6.1",
-    "generator-loopback": "^5.0.0",
+    "generator-loopback": "^5.5.1",
     "minimist": "^1.2.0"
   },
   "devDependencies": {

--- a/test/fixtures/help-lb.txt
+++ b/test/fixtures/help-lb.txt
@@ -2,9 +2,9 @@ Usage:
   lb app [options] [<name>]
 
 Options:
-  -h,   --help             # Print the generator's options and usage
+  -h,   --help             # Print the command's options and usage
         --skip-cache       # Do not remember prompt answers                          Default: false
-        --skip-install     # Do not automatically install dependencies               Default: false
+        --skip-install     # Do not install npm dependencies                         Default: false
         --skip-next-steps  # Do not print "next steps" info
         --explorer         # Add Loopback Explorer to the project (true by default)
         --bluemix          # Set up as a Bluemix app


### PR DESCRIPTION
Due to fixes in https://github.com/strongloop/generator-loopback/pull/332, the messages from `lb -h` command has been changed.  As a result, the `help-lb.txt` in test fixtures needs to be modified for CI to pass. 
