### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -29,18 +29,18 @@
     }
   },
   "dependencies": {
-    "camelcase-keys": "^4.0.0",
-    "debug": "^2.6.1",
-    "generator-loopback": "^5.5.1",
+    "camelcase-keys": "^4.2.0",
+    "debug": "^4.0.1",
+    "generator-loopback": "^5.9.4",
     "minimist": "^1.2.0"
   },
   "devDependencies": {
-    "chai": "^4.1.0",
+    "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
-    "eslint": "^4.3.0",
-    "eslint-config-loopback": "^8.0.0",
+    "eslint": "^5.6.0",
+    "eslint-config-loopback": "^12.0.0",
     "mkdirp": "^0.5.1",
-    "mocha": "^3.2.0",
-    "rimraf": "^2.6.1"
+    "mocha": "^5.2.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/test/help.test.js
+++ b/test/help.test.js
@@ -54,7 +54,8 @@ describe('help', () => {
 
         const expected = fs.readFileSync(
           path.resolve(FIXTURES, helpFile),
-          'utf-8');
+          'utf-8'
+        );
 
         expect(actual).to.equal(expected);
       });

--- a/test/helpers/invoke.js
+++ b/test/helpers/invoke.js
@@ -56,4 +56,4 @@ function invokeCli(args, prompts) {
       resolve({stdout, stderr, exitCode: code});
     });
   });
-};
+}

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -117,7 +117,8 @@ describe('smoke tests - lb', () => {
       })
       .then(() => {
         const modelJson = require(sandbox.resolve(
-          'common/models/test-model.json'));
+          'common/models/test-model.json'
+        ));
         expect(modelJson.name, 'model name in JSON').to.equal('test-model');
       });
   });
@@ -258,8 +259,7 @@ describe('smoke tests - lb', () => {
     };
 
     return givenProjectInSandbox()
-      .then(() => invoke(['swagger'], prompts)
-      ).then(() => {
+      .then(() => invoke(['swagger'], prompts)).then(() => {
         const pets = require(sandbox.resolve('common/models/pets.json'));
         expect(pets.name).to.eql('pets');
         expect(pets.base).to.eql('Model');


### PR DESCRIPTION
### Description

- upgrade dependencies. Explicitly pick up latest version of `generator-loopback@5.9.4` which picks up the latest `loopback-workspace` -- which ensures most up to date connectors and juggler is installed. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
