### PR TITLE
fix tests for prompts

### DIFF
--- a/test/fixtures/help-lb.txt
+++ b/test/fixtures/help-lb.txt
@@ -8,7 +8,6 @@ Options:
         --force-install    # Fail on install dependencies error                      Default: false
         --skip-next-steps  # Do not print "next steps" info
         --explorer         # Add Loopback Explorer to the project (true by default)
-        --loopbackVersion  # Select the LoopBack version
         --template         # Set up the LoopBack application template
         --bluemix          # Set up as a Bluemix app
         --version          # Display version information                             Default: false


### PR DESCRIPTION
### Description
Follow up task for https://github.com/strongloop/generator-loopback/pull/405.
Since we've removed the prompt to ask the LoopBack version number, the tests need to be updated as well. 
