### PR TITLE
chore: update copyright year

### DIFF
--- a/bin/loopback-cli.js
+++ b/bin/loopback-cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/help.test.js
+++ b/test/help.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/helpers/invoke.js
+++ b/test/helpers/invoke.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/helpers/responder.js
+++ b/test/helpers/responder.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION
### Description
Related: strongloop-internal/scrum-apex#440

Update the copyrights year in the rest of the packages besides #4596.

The changes are introduced by running the `slt copyright` command. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
