### PR TITLE
Drop Node.js 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "author": "IBM Corp.",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description
CI for https://github.com/strongloop/loopback-cli/pull/94 is failing because of the unexpected token:
```
/home/travis/build/strongloop/loopback-cli/node_modules/loopback-workspace/node_modules/mkdirp/lib/opts-arg.js:7
    opts = { mode: 0o777 & (~process.umask()), fs, ...opts }
                                                   ^^^
SyntaxError: Unexpected token ...
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
```

Since Node.js 6 has reached EOL, we're dropping the Node.js 6 support. 
I didn't make it to be Node.js 10+ because APIC might need Node.js 8 as well.


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
